### PR TITLE
Delete .dependabot/config.yml

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,6 +1,0 @@
-version: 1
-update_configs:
-  - package_manager: 'github_actions'
-    directory: '/'
-    update_schedule: 'daily'
-    default_reviewers: ['jtakakura']


### PR DESCRIPTION
Dependabot v2 will be released soon, but GitHub Actions is not supported in v2.